### PR TITLE
Fix a probleme in the setTargetPosition function

### DIFF
--- a/src/TMC5160.cpp
+++ b/src/TMC5160.cpp
@@ -209,7 +209,7 @@ void TMC5160::setCurrentPosition(float position, bool updateEncoderPos)
 
 void TMC5160::setTargetPosition(float position)
 {
-	writeRegister(TMC5160_Reg::XTARGET, (int)(position * (float)_uStepCount));
+	writeRegister(TMC5160_Reg::XTARGET, (int32_t)(position * (float)_uStepCount));
 }
 
 void TMC5160::setMaxSpeed(float speed)


### PR DESCRIPTION
In the line 212, we had to change the  position variable casting from int to int32_t, because in our use case we have not got the tune movement.