### PR TITLE
Correcting SPI_MODE0 to SPI_MODE3

### DIFF
--- a/src/TMC5160.h
+++ b/src/TMC5160.h
@@ -221,7 +221,7 @@ class TMC5160_SPI : public TMC5160 {
 public:
 	TMC5160_SPI( uint8_t chipSelectPin,	// pin to use for the SPI bus SS line
 		uint32_t fclk = DEFAULT_F_CLK,
-		const SPISettings &spiSettings = SPISettings(1000000, MSBFIRST, SPI_MODE0), // spi bus settings to use
+		const SPISettings &spiSettings = SPISettings(1000000, MSBFIRST, SPI_MODE3), // spi bus settings to use
 		SPIClass& spi = SPI ); // spi class to use
 
 	uint32_t readRegister(uint8_t address);	// addresses are from TMC5160.h


### PR DESCRIPTION
Trinamic SPI interfaces use SPI_MODE3. Noted in issue #16